### PR TITLE
Feature/ grid/list view 컴포넌트 구현

### DIFF
--- a/app/components/Categories.tsx
+++ b/app/components/Categories.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname, useSearchParams } from 'next/navigation';
-import { FaBook, FaPaintBrush } from 'react-icons/fa';
+import { FaBook, FaFire, FaPaintBrush } from 'react-icons/fa';
 import { FaMagnifyingGlass } from 'react-icons/fa6';
 import { GiTeacher } from 'react-icons/gi';
 import { IoSettings } from 'react-icons/io5';
@@ -11,6 +11,13 @@ import CategoryBox from './CategoryBox';
 import Container from './Container';
 
 export const categories = [
+  {
+    name: 'HOT',
+    label: 'HOT',
+    alias: 'HOT',
+    icon: FaFire,
+    description: '인기게시글과 관련된 정보가 담겨져 있습니다!'
+  },
   {
     name: '전체',
     label: 'ALL',

--- a/app/components/CategoryBox.tsx
+++ b/app/components/CategoryBox.tsx
@@ -47,7 +47,7 @@ const CategoryBox: React.FC<CategoryBoxProps> = ({ icon: Icon, label, selected }
       ${selected ? 'text-blue-400' : 'text-neutral-500'}`}
     >
       <Icon size={26} className="cursor-pointer" />
-      <div className="font-medium text-sm">{label}</div>
+      <div className="font-medium text-[0.7rem] ">{label}</div>
     </div>
   );
 };

--- a/app/components/EmptyState.tsx
+++ b/app/components/EmptyState.tsx
@@ -21,9 +21,7 @@ const EmptyState: React.FC<EmptyState> = ({
     <div className="h-[60vh] flex flex-col gap-2 justify-center items-center">
       <Heading title={title} subtitle={subtitle} center />
       <div className="w-48 mt-4">
-        {!showReset && (
-          <Button outline label="모든 필터 제거하기" onClick={() => router.push('/')} />
-        )}
+        {!showReset && <Button outline label="홈으로 이동하기" onClick={() => router.push('/')} />}
       </div>
     </div>
   );

--- a/app/components/listings/ListingCard.tsx
+++ b/app/components/listings/ListingCard.tsx
@@ -8,6 +8,7 @@ import { Fragment, useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 import ClimbingBoxLoader from 'react-spinners/ClimbingBoxLoader';
 
+import EmptyState from '../EmptyState';
 import ListingGrid from './ListingGrid';
 
 const ListingCard = () => {
@@ -18,7 +19,8 @@ const ListingCard = () => {
     data: listings,
     fetchNextPage,
     hasNextPage,
-    isFetching
+    isFetching,
+    isError
   } = useInfiniteQuery<
     Listing[],
     Object,
@@ -47,6 +49,10 @@ const ListingCard = () => {
       !isFetching && hasNextPage && fetchNextPage();
     }
   }, [inView, isFetching, hasNextPage, fetchNextPage]);
+
+  if (isError || listings?.pages?.length === 0) {
+    return <EmptyState />;
+  }
 
   return (
     <>

--- a/app/components/listings/ListingContainer.tsx
+++ b/app/components/listings/ListingContainer.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { BsFillGridFill, BsList } from 'react-icons/bs';
+
+import Heading from '../Heading';
+import PreviewPostsView from '../post/PreviewPostsView';
+import ListingCard from './ListingCard';
+
+const ListingContainer = () => {
+  const [layout, setLayout] = useState('list');
+  const searchParams = useSearchParams();
+
+  let category = searchParams.get('category');
+
+  if (category === null) {
+    category = '전체';
+  }
+
+  const setActiveStyle = useMemo(() => {
+    return (pattern: string) =>
+      `text-xl rounded-2xl p-2 ${pattern === layout ? 'bg-blue-300' : ''}`;
+  }, [layout]);
+
+  return (
+    <>
+      <div className="p-20 my-10">
+        <Heading title={category} subtitle={`${category} 게시글입니다.`} center />
+        <div className="flex flex-col items-end justify-center">
+          <div className="flex justify-between items-center mt-8 border-b border-base-300 pb-1">
+            <div className="">
+              <button
+                type="button"
+                onClick={() => setLayout('list')}
+                className={setActiveStyle('list')}
+              >
+                <BsList />
+              </button>
+              <button
+                type="button"
+                onClick={() => setLayout('grid')}
+                className={setActiveStyle('grid')}
+              >
+                <BsFillGridFill />
+              </button>
+            </div>
+          </div>
+          <div className="my-2 w-full">
+            {layout === 'grid' ? <ListingCard /> : <PreviewPostsView />}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ListingContainer;

--- a/app/components/listings/ListingGrid.tsx
+++ b/app/components/listings/ListingGrid.tsx
@@ -11,18 +11,17 @@ type ListingGridProps = {
 };
 
 const ListingGrid: React.FC<ListingGridProps> = ({ data }) => {
-  console.log(data);
   const router = useRouter();
   const date = useMemo(() => {
     if (!data.createdAt) {
       return null;
     }
-
     return `${format(data.createdAt, 'yyyy년/MM월/dd일')}`;
   }, [data.createdAt]);
+
   return (
     <div
-      onClick={() => router.push(`/recruitments/${data.postId}`)}
+      onClick={() => router.push(`/post/${data.postId}`)}
       className="col-span-1 cursor-pointer group"
     >
       <div
@@ -43,7 +42,7 @@ const ListingGrid: React.FC<ListingGridProps> = ({ data }) => {
                   group-hover:scale-110
                   transition"
           // 추후 구조 변경하면서 수정 예정!
-          src={data?.imageSrc as string}
+          src={data.Images[0].link}
           alt={`${data.title}이미지`}
         />
         <div className="absolute top-3 right-3">

--- a/app/components/post/ListingPosts.tsx
+++ b/app/components/post/ListingPosts.tsx
@@ -1,36 +1,76 @@
 'use client';
 
-import { getPreviewPosts } from '@/app/lib/getPreviewPosts';
+import { getFilteredPosts } from '@/app/lib/getFilteredPosts';
 import { Listing } from '@/app/types';
-import { useQuery } from '@tanstack/react-query';
+import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+import { Fragment, useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+import ClimbingBoxLoader from 'react-spinners/ClimbingBoxLoader';
 
+import EmptyState from '../EmptyState';
 import PostPreview from './PostPreview';
 
-const ListingPosts = ({ category }: { category: string }) => {
-  const { data: previewPosts } = useQuery<Listing[]>({
-    queryKey: ['previewPosts'],
-    queryFn: () => getPreviewPosts()
+const ListingPosts = () => {
+  const params = useSearchParams();
+  const category = params.get('category') || '';
+  const {
+    data: listings,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isError
+  } = useInfiniteQuery<
+    Listing[],
+    Object,
+    InfiniteData<Listing[]>,
+    [_1: string, _2: string],
+    number
+  >({
+    queryKey: ['posts', category],
+    queryFn: ({ pageParam = 1 }) => getFilteredPosts(category, { pageParam }),
+    initialPageParam: 0,
+    // 가장 최근에 불러왔던 게시글
+    getNextPageParam: (lastPage) => lastPage.at(-1)?.postId,
+    staleTime: 60 * 1000,
+    gcTime: 300 * 1000
   });
 
-  const filteredPosts = previewPosts
-    ?.filter((postData) => category === postData.category)
-    .slice(0, 5);
-  let hotPostsData;
+  const { ref, inView } = useInView({
+    // div가 보이고나서 몇픽셀 정도의 이벤트가 호출될 것 인가? 보이자마자 바로 호출.그래서0
+    threshold: 0,
+    // 몇초후에 딜레이 보일것인지.
+    delay: 0
+  });
 
-  if (category === 'HOT') {
-    hotPostsData = previewPosts?.sort((a, b) => (b?.likes || 0) - (a?.likes || 0));
-    hotPostsData = hotPostsData?.slice(0, 5);
-    return (
-      <div className="flex flex-col p-2  gap-5">
-        {hotPostsData?.map((postData) => <PostPreview key={postData.postId} data={postData} />)}
-      </div>
-    );
+  useEffect(() => {
+    if (inView) {
+      !isFetching && hasNextPage && fetchNextPage();
+    }
+  }, [inView, isFetching, hasNextPage, fetchNextPage]);
+
+  if (isError || listings?.pages?.length === 0) {
+    return <EmptyState />;
   }
 
   return (
-    <div className="flex flex-col p-2  gap-5">
-      {filteredPosts?.map((postData) => <PostPreview key={postData.postId} data={postData} />)}
-    </div>
+    <>
+      <div className="">
+        {listings?.pages.map((page, i) => (
+          <Fragment key={i}>
+            {page.map((listing) => (
+              <PostPreview key={listing.postId} data={listing} />
+            ))}
+          </Fragment>
+        ))}
+      </div>
+      <div style={{ height: 100 }} ref={ref} />
+      {isFetching && (
+        <div className="flex items-center justify-center">
+          <ClimbingBoxLoader color="#36d7b7" size={20} />
+        </div>
+      )}
+    </>
   );
 };
 

--- a/app/components/post/PostPreview.tsx
+++ b/app/components/post/PostPreview.tsx
@@ -11,6 +11,7 @@ type PostPreviewProps = {
 
 const PostPreview: React.FC<PostPreviewProps> = ({ data }) => {
   const router = useRouter();
+
   const date = useMemo(() => {
     if (!data.createdAt) {
       return null;
@@ -20,7 +21,7 @@ const PostPreview: React.FC<PostPreviewProps> = ({ data }) => {
   }, [data.createdAt]);
 
   return (
-    <div className="rounded-lg p-2 hover:bg-slate-300   hover:dark:bg-slate-500 transition cursor-pointer">
+    <div className="rounded-lg p-2 hover:bg-slate-300 hover:dark:bg-slate-500 transition cursor-pointer">
       <div
         className="flex flex-col "
         onClick={() => {

--- a/app/components/post/PreviewPostsView.tsx
+++ b/app/components/post/PreviewPostsView.tsx
@@ -1,49 +1,11 @@
+import Container from '../Container';
 import ListingPosts from './ListingPosts';
 
 const PreviewPostsView = () => {
   return (
-    <div className="max-w-6xl flex justify-center items-center flex-wrap h-screen gap-4">
-      <div className="w-80">
-        <div className="flex mb-3 text-lg font-bold text-neutral-100 bg-blue-500 h-12 items-center justify-center rounded-md">
-          🔥 HOT 🔥
-        </div>
-        <ListingPosts category="HOT" />
-      </div>
-      <div className="w-80">
-        <div className="flex mb-3 text-lg font-bold text-neutral-100 bg-blue-500 h-12 items-center justify-center rounded-md">
-          경영경제대학
-        </div>
-        <ListingPosts category="경영경제대학" />
-      </div>
-
-      <div className="w-80">
-        <div className="flex mb-3 text-lg font-bold text-neutral-100 bg-blue-500 h-12 items-center justify-center rounded-md">
-          융합공과대학
-        </div>
-        <ListingPosts category="융합공과대학" />
-      </div>
-
-      <div className="w-80">
-        <div className="flex mb-3 text-lg font-bold text-neutral-100 bg-blue-500 h-12 items-center justify-center rounded-md">
-          문화예술대학
-        </div>
-        <ListingPosts category="문화예술대학" />
-      </div>
-
-      <div className="w-80">
-        <div className="flex mb-3 text-lg font-bold text-neutral-100 bg-blue-500 h-12 items-center justify-center rounded-md">
-          사범대학
-        </div>
-        <ListingPosts category="사범대학" />
-      </div>
-
-      <div className="w-80">
-        <div className="flex mb-3 text-lg font-bold text-neutral-100 bg-blue-500 h-12 items-center justify-center rounded-md">
-          인문사회과학대학
-        </div>
-        <ListingPosts category="인문사회과학대학" />
-      </div>
-    </div>
+    <Container>
+      <ListingPosts />
+    </Container>
   );
 };
 

--- a/app/lib/getFilteredPosts.ts
+++ b/app/lib/getFilteredPosts.ts
@@ -3,8 +3,11 @@ type Props = {
 };
 
 export const getFilteredPosts = async (params: string, { pageParam }: Props) => {
-  console.log(params, '파람');
-  const url = `${process.env.NEXT_PUBLIC_URL}/api/posts?category=${params}&cursor=${pageParam}`;
+  let url = `${process.env.NEXT_PUBLIC_URL}/api/posts?category=${params}&cursor=${pageParam}`;
+  if (params === '') {
+    url = `${process.env.NEXT_PUBLIC_URL}/api/posts?category=전체`;
+  }
+
   // if (params === '') {
   //   url = `${process.env.NEXT_PUBLIC_URL}/api/posts?category=전체`;
   // }

--- a/app/lib/getPreviewPosts.ts
+++ b/app/lib/getPreviewPosts.ts
@@ -1,9 +1,0 @@
-export const getPreviewPosts = async () => {
-  const url = `${process.env.NEXT_PUBLIC_URL}/api/preview/posts`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error('Failed to fetch data');
-  }
-
-  return res.json();
-};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,8 @@
 import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
 
 import Container from './components/Container';
-import Heading from './components/Heading';
-import ListingCard from './components/listings/ListingCard';
-import PreviewPostsView from './components/post/PreviewPostsView';
+import ListingContainer from './components/listings/ListingContainer';
 import { getFilteredPosts } from './lib/getFilteredPosts';
-import { getPreviewPosts } from './lib/getPreviewPosts';
 
 type HomeProps = {
   searchParams?: {
@@ -25,27 +22,13 @@ const Home: React.FC<HomeProps> = async ({ searchParams }) => {
     initialPageParam: 0
   });
 
-  await queryClient.prefetchQuery({
-    queryKey: ['previewPosts'],
-    queryFn: () => getPreviewPosts()
-  });
-
   // hydrate라는 것은 서버에서 온 데이터를 클라이언트에서 그대로, 물려받는 것 이다.
   const dehydratedState = dehydrate(queryClient);
 
   return (
     <HydrationBoundary state={dehydratedState}>
       <Container>
-        <div className="p-20 flex flex-col items-center justify-center">
-          {category === '' && (
-            <div className="py-10">
-              <Heading title="취업정보 교류글" subtitle="취업 정보 교류" center />
-              <PreviewPostsView />
-            </div>
-          )}
-          <Heading title="프로젝트/스터디 모집글" subtitle="취업 정보 교류" center />
-          <ListingCard />
-        </div>
+        <ListingContainer />
       </Container>
     </HydrationBoundary>
   );

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { HttpResponse, delay, http } from 'msw';
+import { HttpResponse, http } from 'msw';
 
 import { postData } from './data';
 
@@ -42,11 +42,9 @@ export const handlers = [
     });
   }),
   http.get('/api/posts', async ({ request }) => {
-    await delay(5000);
     const url = new URL(request.url);
     const category = url.searchParams.get('category') || '전체';
     const cursor = parseInt(url.searchParams.get('cursor') as string) || 0;
-    console.log(url.searchParams);
 
     if (category === '전체') {
       // Handle 전체 category
@@ -63,7 +61,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -78,7 +93,7 @@ export const handlers = [
         {
           postId: cursor + 2,
           User: User[1],
-          title: `${cursor + 2}역사 스터디 인원 모집 현재 3/5`,
+          title: `${cursor + 2}수학 스터디 인원 모집 현재 3/5`,
           type: 'recruit',
           category: '인문사회과학대학',
           createdAt: new Date(),
@@ -87,7 +102,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -102,7 +134,7 @@ export const handlers = [
         {
           postId: cursor + 3,
           User: User[1],
-          title: `${cursor + 3}역사 스터디 인원 모집 현재 3/5`,
+          title: `${cursor + 3}코테 스터디 인원 모집 현재 3/5`,
           type: 'recruit',
           category: '인문사회과학대학',
           createdAt: new Date(),
@@ -111,7 +143,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -126,7 +175,7 @@ export const handlers = [
         {
           postId: cursor + 4,
           User: User[1],
-          title: `${cursor + 4}역사 스터디 인원 모집 현재 3/5`,
+          title: `${cursor + 4}리액트 스터디 인원 모집 현재 3/5`,
           type: 'recruit',
           category: '인문사회과학대학',
           createdAt: new Date(),
@@ -135,7 +184,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -150,7 +216,7 @@ export const handlers = [
         {
           postId: cursor + 5,
           User: User[1],
-          title: `${cursor + 5}역사 스터디 인원 모집 현재 3/5`,
+          title: `${cursor + 5}Type Script 스터디 인원 모집 현재 3/5`,
           type: 'recruit',
           category: '인문사회과학대학',
           createdAt: new Date(),
@@ -159,7 +225,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -190,7 +273,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -220,7 +320,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -250,7 +367,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -280,7 +414,24 @@ export const handlers = [
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,
@@ -299,18 +450,35 @@ export const handlers = [
       // Handle 문화예술대학 category
       return HttpResponse.json([
         {
-          postId: cursor + 5,
+          postId: 5,
           User: User[1],
-          title: `${cursor + 5}역사 스터디 인원 모집 현재 3/5`,
+          title: '미술 스터디 인원 모집 현재 3/5',
           type: 'recruit',
-          category: '인문사회과학대학',
+          category: '문화예술대학',
           createdAt: new Date(),
-          content: `${cursor + 5} 재밌는 역사 스터디에 오세요!!`,
+          content: '재밌는 미술 스터디에 오세요',
           memberCount: 4,
           dueDate: new Date(),
           place: '상명대학교 L507 학술정보관',
           isOnline: '오프라인 | 온라인',
-          imageSrc: faker.image.urlLoremFlickr(),
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
           Comments: [
             {
               commentId: 1,


### PR DESCRIPTION
## 작업내용
Grid View, List View 데이터 연동 및 List View 무한스크롤 기능 추가, Post Detail Page 수정
HOT 카테고리 추가


## 스크린샷/GIF
https://github.com/SMUING-D/FE-Next/assets/119042360/fcad44a5-d29d-493f-807a-8f8f63ad22a0


## 공유사항
- [x] Grid / List 아이콘 클릭시, 해당하는 뷰로 게시글 시청 가능.
- [x] 반응형 디자인 구현 완료
- [x] HOT 카테고리 추가
- [x] 데이터 fetching 실패 또는, 없을 시 EmptyState 컴포넌트 보이게 구현.
- [x] detail-page 한가지로 통일, 데이터 구조 통일 
- [x] 쿼리파라미터 cursor 방식으로 데이터를 불러옵니다.
- [x] msw, faker이용 가상 데이터 무제한 생성 구현
- [x] react-intersection observer 이용.
- [x] react-spinners 이용



## 이슈/건의/전달 사항
- [ ] 2차 merge 이후, Suspense 활용 Skeleton UI 도입해보겠습니다~!
- [ ] 회의했을 떄 main에 HOT 게시글 보여주기로했는데, 현재 HOT 게시글이 없어서, 보기 나빠서, 일단은 전체 게시글로 구현 진행했습니다. 근데 정말 서비스 초기에 Hot 게시글이 없을 수 있기 때문에, 메인 페이지 디자인을 조금 다르게 수정을 하는게 좋지 않을까 싶긴한데 이부분은 다음 회의때 한번 이야기 나누어보면 좋을 것 같습니다!!



