### PR TITLE
Feature/categories

### DIFF
--- a/app/components/listings/ListingCard.tsx
+++ b/app/components/listings/ListingCard.tsx
@@ -14,6 +14,8 @@ import ListingGrid from './ListingGrid';
 const ListingCard = () => {
   const params = useSearchParams();
   const category = params.get('category') || '';
+  const info = params.get('info') || '';
+  const search = params.get('search') || '';
 
   const {
     data: listings,
@@ -25,11 +27,11 @@ const ListingCard = () => {
     Listing[],
     Object,
     InfiniteData<Listing[]>,
-    [_1: string, _2: string],
+    [_1: string, _2: string, _3: string, _4: string],
     number
   >({
-    queryKey: ['posts', category],
-    queryFn: ({ pageParam = 1 }) => getFilteredPosts(category, { pageParam }),
+    queryKey: ['posts', category, info, search],
+    queryFn: ({ pageParam = 1 }) => getFilteredPosts(category, info, search, { pageParam }),
     initialPageParam: 0,
     // 가장 최근에 불러왔던 게시글
     getNextPageParam: (lastPage) => lastPage.at(-1)?.postId,

--- a/app/components/listings/ListingContainer.tsx
+++ b/app/components/listings/ListingContainer.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { BsFillGridFill, BsList } from 'react-icons/bs';
 
 import Heading from '../Heading';
+import Search from '../navbar/Search';
 import PreviewPostsView from '../post/PreviewPostsView';
 import ListingCard from './ListingCard';
 
@@ -87,6 +88,12 @@ const ListingContainer = () => {
           >
             <h3>취업 / 정보 교류</h3>
           </button>
+        </div>
+        <div
+          className="flex items-center
+        justify-center p-10"
+        >
+          <Search />
         </div>
         <div className="my-2 w-full">
           {layout === 'grid' ? <ListingCard /> : <PreviewPostsView />}

--- a/app/components/listings/ListingContainer.tsx
+++ b/app/components/listings/ListingContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useMemo, useState } from 'react';
 import { BsFillGridFill, BsList } from 'react-icons/bs';
 
 import Heading from '../Heading';
@@ -10,7 +10,21 @@ import ListingCard from './ListingCard';
 
 const ListingContainer = () => {
   const [layout, setLayout] = useState('grid');
+  const [select, setSelect] = useState('');
+  const router = useRouter();
   const searchParams = useSearchParams();
+
+  const onChangeInfo = useCallback(() => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.set('info', 'on');
+    router.replace(`?${newSearchParams.toString()}`);
+  }, [router, searchParams]);
+
+  const onChangeStudy = useCallback(() => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.delete('info');
+    router.replace(`?${newSearchParams.toString()}`);
+  }, [router, searchParams]);
 
   let category = searchParams.get('category');
 
@@ -22,6 +36,11 @@ const ListingContainer = () => {
     return (pattern: string) =>
       `text-xl rounded-2xl p-2 ${pattern === layout ? 'bg-blue-300' : ''}`;
   }, [layout]);
+
+  const setActiveSelectStyle = useMemo(() => {
+    return (pattern: string) =>
+      `text-xl rounded-2xl p-2 ${pattern === select ? 'bg-blue-300' : ''}`;
+  }, [select]);
 
   return (
     <>
@@ -46,9 +65,31 @@ const ListingContainer = () => {
               </button>
             </div>
           </div>
-          <div className="my-2 w-full">
-            {layout === 'grid' ? <ListingCard /> : <PreviewPostsView />}
-          </div>
+        </div>
+        <div className="flex items-center justify-center gap-5">
+          <button
+            type="button"
+            onClick={() => {
+              onChangeStudy();
+              setSelect('study');
+            }}
+            className={setActiveSelectStyle('study')}
+          >
+            <h3>스터디 / 프로젝트 모집</h3>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onChangeInfo();
+              setSelect('info');
+            }}
+            className={setActiveSelectStyle('info')}
+          >
+            <h3>취업 / 정보 교류</h3>
+          </button>
+        </div>
+        <div className="my-2 w-full">
+          {layout === 'grid' ? <ListingCard /> : <PreviewPostsView />}
         </div>
       </div>
     </>

--- a/app/components/listings/ListingContainer.tsx
+++ b/app/components/listings/ListingContainer.tsx
@@ -9,7 +9,7 @@ import PreviewPostsView from '../post/PreviewPostsView';
 import ListingCard from './ListingCard';
 
 const ListingContainer = () => {
-  const [layout, setLayout] = useState('list');
+  const [layout, setLayout] = useState('grid');
   const searchParams = useSearchParams();
 
   let category = searchParams.get('category');
@@ -32,17 +32,17 @@ const ListingContainer = () => {
             <div className="">
               <button
                 type="button"
-                onClick={() => setLayout('list')}
-                className={setActiveStyle('list')}
-              >
-                <BsList />
-              </button>
-              <button
-                type="button"
                 onClick={() => setLayout('grid')}
                 className={setActiveStyle('grid')}
               >
                 <BsFillGridFill />
+              </button>
+              <button
+                type="button"
+                onClick={() => setLayout('list')}
+                className={setActiveStyle('list')}
+              >
+                <BsList />
               </button>
             </div>
           </div>

--- a/app/components/navbar/Navbar.tsx
+++ b/app/components/navbar/Navbar.tsx
@@ -1,7 +1,6 @@
 import Categories from '../Categories';
 import Container from '../Container';
 import Logo from './Logo';
-import Search from './Search';
 import ThemeToggle from './ThemeToggle';
 import UserMenu from './UserMenu';
 
@@ -12,9 +11,10 @@ const Navbar = () => {
         <Container>
           <div className="dark:text-white flex flex-row items-center justify-between gap-3 md:gap-3">
             <Logo />
-            <Search />
-            <ThemeToggle />
-            <UserMenu />
+            <div className="flex items-center gap-5">
+              <ThemeToggle />
+              <UserMenu />
+            </div>
           </div>
         </Container>
       </div>

--- a/app/components/navbar/Search.tsx
+++ b/app/components/navbar/Search.tsx
@@ -1,28 +1,41 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { FormEventHandler } from 'react';
 import { BiSearch } from 'react-icons/bi';
 
 const Search = () => {
-  const [userInput, setUserInput] = useState(''); //eslint-disable-line no-unused-vars
+  const searchParams = useSearchParams();
+  const router = useRouter();
 
-  const handleChangeInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setUserInput(e.target.value);
-  }, []);
+  const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+    const newSearchParams = new URLSearchParams(searchParams);
+    const searchValue = e.currentTarget.search.value;
+    console.log(e.currentTarget.search.value);
+
+    if (!searchValue) {
+      router.replace(`?category=${newSearchParams.get('category') || ''}`);
+    } else {
+      newSearchParams.set('search', searchValue);
+      router.replace(`?${newSearchParams.toString()}`);
+    }
+  };
 
   return (
-    <div className="md:w-2/4 border-[1px] p-2 rounded-full shadow-sm">
+    <form onSubmit={onSubmit} className="md:w-2/4 border-[1px] p-2 rounded-full shadow-sm">
       <div className="flex flex-row items-center justify-center ">
         <input
           className="w-full p-1 bg-transparent"
           placeholder="검색어를 입력해주세요"
-          onChange={handleChangeInput}
+          name="search"
+          type="search"
         />
-        <div className="p-2 bg-blue-500 rounded-full text-white">
+        <button type="submit" className="p-2 bg-blue-500 rounded-full text-white cursor-pointer">
           <BiSearch size={18} />
-        </div>
+        </button>
       </div>
-    </div>
+    </form>
   );
 };
 

--- a/app/components/post/ListingPosts.tsx
+++ b/app/components/post/ListingPosts.tsx
@@ -55,7 +55,7 @@ const ListingPosts = () => {
 
   return (
     <>
-      <div className="">
+      <div className="mt-10">
         {listings?.pages.map((page, i) => (
           <Fragment key={i}>
             {page.map((listing) => (

--- a/app/components/post/ListingPosts.tsx
+++ b/app/components/post/ListingPosts.tsx
@@ -14,6 +14,8 @@ import PostPreview from './PostPreview';
 const ListingPosts = () => {
   const params = useSearchParams();
   const category = params.get('category') || '';
+  const info = params.get('info') || '';
+  const search = params.get('search') || '';
   const {
     data: listings,
     fetchNextPage,
@@ -24,11 +26,11 @@ const ListingPosts = () => {
     Listing[],
     Object,
     InfiniteData<Listing[]>,
-    [_1: string, _2: string],
+    [_1: string, _2: string, _3: string, _4: string],
     number
   >({
-    queryKey: ['posts', category],
-    queryFn: ({ pageParam = 1 }) => getFilteredPosts(category, { pageParam }),
+    queryKey: ['posts', category, info, search],
+    queryFn: ({ pageParam = 1 }) => getFilteredPosts(category, info, search, { pageParam }),
     initialPageParam: 0,
     // 가장 최근에 불러왔던 게시글
     getNextPageParam: (lastPage) => lastPage.at(-1)?.postId,

--- a/app/lib/getFilteredPosts.ts
+++ b/app/lib/getFilteredPosts.ts
@@ -2,10 +2,24 @@ type Props = {
   pageParam?: number;
 };
 
-export const getFilteredPosts = async (params: string, { pageParam }: Props) => {
+export const getFilteredPosts = async (
+  params: string,
+  info: string,
+  search: string,
+  { pageParam }: Props
+) => {
   let url = `${process.env.NEXT_PUBLIC_URL}/api/posts?category=${params}&cursor=${pageParam}`;
+
   if (params === '') {
     url = `${process.env.NEXT_PUBLIC_URL}/api/posts?category=전체`;
+  }
+
+  if (info !== '') {
+    url += `&info=${info}`;
+  }
+
+  if (search !== '') {
+    url += `&search=${search}`;
   }
 
   // if (params === '') {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,17 +7,23 @@ import { getFilteredPosts } from './lib/getFilteredPosts';
 type HomeProps = {
   searchParams?: {
     category?: string;
+    info?: '' | 'on';
+    search?: string;
   };
 };
 
 const Home: React.FC<HomeProps> = async ({ searchParams }) => {
   const queryClient = new QueryClient();
   const category = searchParams?.category || '';
+  const info = searchParams?.info || '';
+  const search = searchParams?.search || '';
+
+  console.log(info, search);
 
   // 서버에서 불러온 데이터를 클라이언트의 리액트 쿼리가 물려받음.(하이드레이트)
   await queryClient.prefetchInfiniteQuery({
-    queryKey: ['posts', category],
-    queryFn: ({ pageParam = 1 }) => getFilteredPosts(category, { pageParam }), // searchParams 전달
+    queryKey: ['posts', category, info, search],
+    queryFn: ({ pageParam = 1 }) => getFilteredPosts(category, info, search, { pageParam }), // searchParams 전달
     // 커서 값
     initialPageParam: 0
   });

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -43,7 +43,54 @@ export const handlers = [
     const url = new URL(request.url);
     const category = url.searchParams.get('category') || '전체';
     const cursor = parseInt(url.searchParams.get('cursor') as string) || 0;
+    const info = url.searchParams.get('info');
+    const search = url.searchParams.get('search');
 
+    if (category === '경영경제대학' && info === 'on' && search === '김용민') {
+      return HttpResponse.json([
+        {
+          postId: cursor + 1,
+          User: User[1],
+          title: `${cursor + 1}김용민 게시글`,
+          type: 'recruit',
+          category: '인문사회과학대학',
+          createdAt: new Date(),
+          content: `${cursor + 1} 재밌는 역사 스터디에 오세요!!`,
+          memberCount: 4,
+          dueDate: new Date(),
+          place: '상명대학교 L507 학술정보관',
+          isOnline: '오프라인 | 온라인',
+          Images: [
+            {
+              imageId: 1,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 2,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 3,
+              link: faker.image.urlLoremFlickr()
+            },
+            {
+              imageId: 4,
+              link: faker.image.urlLoremFlickr()
+            }
+          ],
+          Comments: [
+            {
+              commentId: 1,
+              User: User[2],
+              content: '재밌당',
+              createdAt: new Date(),
+              likes: 10,
+              reports: 1
+            }
+          ]
+        }
+      ]);
+    }
     if (category === '전체') {
       // Handle 전체 category
       return HttpResponse.json([


### PR DESCRIPTION
## 작업내용
1/15 (월)

1. 기존, 리스트 뷰를 먼저 보여주는 방향에서, 그리드 뷰를 먼저 보여주는 것으로 변경
2. 기존 전체 포스트를 보여주는 방향성에서 -> 스터디 / 프로젝트 모집, 취업 / 정보 교류 카테고리를 클릭할 수 있도록 설정. 
3. 해당 카테고리 클릭시 쿼리파라미터 형식으로 변경
-> 스터디 / 프로젝트 모집 클릭시 쿼리파라미터 없고,
-> 취업 / 정보 교류 클릭시 ?info=on 형식으로 쿼리파라미터가 기존 쿼리파람에 이어서 붙습니다.

1/16 (화)

1. 기존 Navbar의 Search 컴포넌트 삭제 후, 각 카테고리 페이지에 검색기능 추가
2. 검색시 search=검색어 쿼리파라미터로 들어감, 돋보기 아이콘 클릭시에도, 동일하기 동작.
3. 기존 tanstack-query 로직에 info, search 쿼리파람 추가.
4. filteredPosts 로직에도, info, search 쿼리파람 반영, 로직 변경.
5. info, search 쿼리파람 반영에 따른 msw 로직 변경

## 스크린샷/GIF
1/15 (월) 작업내용 완료 인증샷

<img width="963" alt="스크린샷 2024-01-15 오후 6 30 58" src="https://github.com/SMUING-D/FE-Next/assets/119042360/d1bc1f96-b4aa-4747-bcc2-f96f35258481">
<img width="954" alt="스크린샷 2024-01-15 오후 6 31 13" src="https://github.com/SMUING-D/FE-Next/assets/119042360/570e8e5f-8076-4aa1-9604-26ecf663e2ba">

1/16 (화) 작업내용 완료 인증샷

<img width="1493" alt="스크린샷 2024-01-16 오전 3 49 58" src="https://github.com/SMUING-D/FE-Next/assets/119042360/4fd8702b-90f3-43a3-b4ae-c1d8985809fe">


## 작업 사항

1/15 (월)

- [x] 기존, 리스트 뷰를 먼저 보여주는 방향에서, 그리드 뷰를 먼저 보여주는 것으로 변경하였습니다.
- [x] 기존 전체 포스트를 보여주는 방향성에서 -> 스터디 / 프로젝트 모집, 취업 / 정보 교류 카테고리를 선택하여, 유저가 원하는 카테고리를 클릭할 수 있도록 설정가능하도록 구현하였습니다.
- [x] 해당 카테고리 클릭시 쿼리파라미터를 기존 파람에 이어붙이는 형식으로 변경
- [x] 취업 / 정보 교류 클릭시 ?info=on 형식으로 쿼리파라미터가 기존 쿼리파람에 이어서 붙습니다.
- [x] 스터디 / 프로젝트 모집 클릭시 쿼리파라미터 없어짐(?info=on을 뺌.)

1/16 (화)

- [x] 기존 Navbar의 Search 컴포넌트 삭제 후, 각 카테고리 페이지에 검색기능 추가
- [x]  검색시 search=검색어 쿼리파라미터로 들어감, 돋보기 아이콘 클릭시에도, 동일하기 동작.
- [x] 기존 tanstack-query 로직에 info, search 쿼리파람 추가, 캐싱 쿼리키 반영.
- [x] filteredPosts 로직에도, info, search 쿼리파람 반영, 로직 변경. 
- [x] info, search 쿼리파람 반영에 따른 msw 로직 변경 

## 이슈/건의/전달 사항
- [ ] 폰트와 디자인은 금요일 회의 떄 같이 변경하는 것으로!!
- [ ] 백엔드 ERD 나왔고, 목요일날, API 명세서 나온다고해서, 그거 바탕으로 msw mock 데이터 금요일날 같이 수정하는 것으로!!
- [ ] Suspense는 저번 회의에도 말했듯이, 전체 완성 이후에 도입을 목표로!!
- [ ] 확인하고 컨펌 리뷰 부탁드릴게유~


