### PR TITLE
Feat: Feature/login auth

### DIFF
--- a/app/components/modals/RegisterModal.tsx
+++ b/app/components/modals/RegisterModal.tsx
@@ -193,7 +193,7 @@ const RegisterModal = () => {
           required
         />
         <div className="w-32 ml-auto">
-          <Button label="인증번호 전송" onClick={onClickPostAuthNum} />
+          <Button label="인증번호 받기" onClick={onClickPostAuthNum} />
         </div>
       </div>
       {isAuthNum && <div className="font-medium text-gray-400">인증번호가 전송되었습니다.</div>}

--- a/app/lib/verifyAuthNum.ts
+++ b/app/lib/verifyAuthNum.ts
@@ -1,5 +1,5 @@
-const sendAuthMail = async (email: string) => {
-  const url = `${process.env.NEXT_PUBLIC_URL}/api/auth/email/send?email=${email}`;
+const verifyAuthNum = async (email: string, authNum: string) => {
+  const url = `${process.env.NEXT_PUBLIC_URL}/api/auth/email/verify?email=${email}&authNum=${authNum}`;
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -17,4 +17,4 @@ const sendAuthMail = async (email: string) => {
   }
 };
 
-export default sendAuthMail;
+export default verifyAuthNum;

--- a/app/schema/user.tsx
+++ b/app/schema/user.tsx
@@ -41,27 +41,7 @@ const schema = z
       .min(1, { message: '학번을 작성해주세요' })
       .refine((value) => value.length === 9, {
         message: '학번은 정확히 9자리여야 합니다.'
-      }),
-    grade: z.coerce.string().min(1, { message: '학년을 선택해주세요' }),
-    school: z
-      .string()
-      .min(1, { message: '학교를 입력해주세요' })
-      .transform((v) => v.replace(/ /g, ' ')),
-    major: z
-      .string()
-      .min(1, { message: '전공을 입력해주세요' })
-      .transform((v) => v.replace(/ /g, ' ')),
-    college: z
-      .string()
-      .min(1, { message: '단과대를 선택해주세요' })
-      .transform((v) => v.replace(/ /g, ' ')),
-    subMajor: z.string().transform((v) => v.replace(/ /g, ' ')),
-    desiredEmployment: z.string().transform((v) => v.replace(/ /g, ' ')),
-    skill: z.string().transform((v) => v.replace(/ /g, ' ')),
-    educationalStatus: z
-      .string()
-      .min(1, { message: '학위를 선택해주세요' })
-      .transform((v) => v.replace(/ /g, ' '))
+      })
   })
   .refine((data) => data.password === data.confirmPassword, {
     message: '비밀번호가 일치하지 않습니다',

--- a/mocks/handler/authHandler.ts
+++ b/mocks/handler/authHandler.ts
@@ -24,5 +24,18 @@ export const AuthHandlers = [
         'Set-Cookie': 'connect.sid=msw-cookie;HttpOnly;Path=/'
       }
     });
+  }),
+  // 인증번호 보내기
+  http.post('/api/auth/email/send', ({ request }) => {
+    const url = new URL(request.url);
+    const email = url.searchParams.get('email');
+    return email && HttpResponse.json('10101');
+  }),
+  // 인증번호 받아서 검증
+  http.post('/api/auth/email/verify', ({ request }) => {
+    const url = new URL(request.url);
+    const email = url.searchParams.get('email');
+    const authNum = url.searchParams.get('authNum');
+    return authNum === '10101' && email ? HttpResponse.json(true) : HttpResponse.json(false);
   })
 ];


### PR DESCRIPTION
## 작업 사항

1. authHandler 인증번호 이메일로 전송, 인증번호 확인 handler 추가
2. 인증번호 전송, 인증번호 확인 api
3. 회원가입 모달 이메일 인증 로직 추가, 가입 절차 수정 (이메일 인증, 학번, 비밀번호, 비밀번호 확인, 이름, 닉네임, 프로필사진)
4. 비밀번호 찾기 이메일 인증 로직 변경


## 스크린샷/GIF
![image](https://github.com/SMUING-D/FE-Next/assets/104924817/c43ef3e9-3486-4d25-8351-1a56f4f8917e)
![image](https://github.com/SMUING-D/FE-Next/assets/104924817/2912da5d-66c6-4929-b28a-3db077828e33)



## 작업 사항
- [x] authHandler 인증번호 이메일로 전송, 인증번호 확인 handler 추가
- [x] 인증번호 전송, 인증번호 확인 api
- [x] 회원가입 모달 이메일 인증 로직 추가, 가입 절차 수정 (이메일 인증, 학번, 비밀번호, 비밀번호 확인, 이름, 닉네임, 프로필사진)
- [x] 비밀번호 찾기 이메일 인증 로직 변경


## 이슈/건의/전달 사항
- [ ] 인증번호 받기 버튼 텍스트가 깨지네염
- [ ] 브랜치 이름이 login-auth인건 실수입니다. 작업은 회원가입과 비밀번호 찾기 부분을 했습니다
- [ ] 회원가입할 때 일단 학번을 받기는 했는데, 이메일 인증할 때 이미 학번을 포함한 이메일로 학교인증을 하기 때문에 굳이? 따로 받아야 싶기도 하네염. 오히려 개인정보 데이터에 방해를 하는게 아닐까 싶은..
- [ ] 메일 인증 번호 10101 입니다
