### PR TITLE
feat: 대댓글 UI 구현, 대댓글 관련 api

### DIFF
--- a/app/components/replyComments/ReplyCommentInput.tsx
+++ b/app/components/replyComments/ReplyCommentInput.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+// import postReplyComment from '@/app/lib/post/postReplyComment';
+import Button from '../Button';
+
+const ReplyCommentInput = ({}) => {
+  const postReComment = async () => {
+    // const res = await postReplyComment(userId, reComments, postId, commentId);
+  };
+  return (
+    <div className="flex flex-col gap-5 sm:flex-row ml-20">
+      <div className="flex w-full items-center justify-center gap-2 h-full p-4 rounded-lg">
+        <input
+          className="text-sm rounded-md border-2 h-full p-5 flex-1 outline-none"
+          placeholder="대댓글을 남겨보세요"
+        />
+        <div className="w-15">
+          <Button onClick={() => postReComment()} label="대댓글 달기" small={true} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReplyCommentInput;

--- a/app/components/replyComments/ReplyCommentListView.tsx
+++ b/app/components/replyComments/ReplyCommentListView.tsx
@@ -1,29 +1,44 @@
-import { COMMENT_DTO } from '@/app/types';
+import likeReplyComment from '@/app/lib/post/likeReplyComment';
+import reportReplyComment from '@/app/lib/post/reportReplyComment';
+import { COMMENT_REPLY_DTO } from '@/app/types';
 import { format } from 'date-fns';
 import { useSession } from 'next-auth/react';
-import { useState } from 'react';
-// import { useRouter } from 'next/navigation';
 import toast from 'react-hot-toast';
-import { FaComments, FaHeart, FaTrashAlt } from 'react-icons/fa';
+import { FaHeart, FaTrashAlt } from 'react-icons/fa';
 import { PiSirenFill } from 'react-icons/pi';
 
 import Avatar from '../Avatar';
-import ReplyCommentInput from '../replyComments/ReplyCommentInput';
-import ReplyCommentListView from '../replyComments/ReplyCommentListView';
 
-type CommentViewProps = {
-  commentsList: COMMENT_DTO[];
+type ReplyCommentListViewProps = {
+  postId: number;
+  commentReplyList: COMMENT_REPLY_DTO[];
 };
 
-const CommentView = ({ commentsList }: CommentViewProps) => {
+const ReplyCommentListView = ({ postId, commentReplyList }: ReplyCommentListViewProps) => {
   const { data: session } = useSession();
-  const [isOpenReplyCommentInput, setIsOpenReplyCommentInput] = useState(false);
   const user = session?.user?.name;
-  // const router = useRouter();
+
+  const reportReComment = async (commentId: number) => {
+    const res = await reportReplyComment(postId, commentId);
+    if (res) {
+      toast('대댓글이 신고되었습니다');
+    } else {
+      toast('오류가 발생했습니다. 다시 시도해주세요');
+    }
+  };
+
+  const likeReComment = async (commentId: number) => {
+    const res = await likeReplyComment(postId, commentId);
+    if (res) {
+      toast('대댓글이 좋아요 되었습니다');
+    } else {
+      toast('오류가 발생했습니다. 이후에 다시 시도해주세요');
+    }
+  };
 
   return (
-    <div className="flex flex-col gap-10">
-      {commentsList?.map(({ id, content, createdAt, userDto, commentReplyList }) => (
+    <div className="flex flex-col gap-3 ml-20 mt-5">
+      {commentReplyList?.map(({ id, content, createdAt, userDto }) => (
         <div key={id} className="flex flex-col">
           <div className="flex flex-col p-3 border-b-2 border-gray-100 gap-3">
             <div className="flex flex-row gap-3 items-center">
@@ -47,21 +62,10 @@ const CommentView = ({ commentsList }: CommentViewProps) => {
                   <PiSirenFill
                     className="flex mr-2 dark:text-zinc-100 text-zinc-400 cursor-pointer"
                     onClick={() =>
-                      session ? toast('댓글이 신고되었습니다') : toast('로그인이 필요한 기능입니다')
+                      session ? reportReComment(id) : toast('로그인이 필요한 기능입니다')
                     }
                   />
                 )}
-                <FaComments
-                  className="flex dark:text-zinc-100 text-zinc-400 cursor-pointer"
-                  onClick={() =>
-                    session
-                      ? setIsOpenReplyCommentInput(!isOpenReplyCommentInput)
-                      : toast('로그인이 필요한 기능입니다')
-                  }
-                />
-                <div className="flex text-xs dark:text-zinc-100 text-zinc-300">
-                  {commentReplyList.length}
-                </div>
               </div>
             </div>
             <div className="flex text-sm dark:text-zinc-100 text-zinc-500 font-normal">
@@ -73,17 +77,15 @@ const CommentView = ({ commentsList }: CommentViewProps) => {
               </div>
               <FaHeart
                 className="flex dark:text-zinc-100 text-zinc-400 cursor-pointer"
-                onClick={() => (session ? '' : toast('로그인이 필요한 기능입니다'))}
+                onClick={() => (session ? likeReComment(id) : toast('로그인이 필요한 기능입니다'))}
               />
               <div className="flex text-xs font-nomal dark:text-zinc-100 text-zinc-300">2</div>
             </div>
           </div>
-          {isOpenReplyCommentInput && <ReplyCommentInput />}
-          <ReplyCommentListView postId={id} commentReplyList={commentReplyList} />
         </div>
       ))}
     </div>
   );
 };
 
-export default CommentView;
+export default ReplyCommentListView;

--- a/app/lib/getDetailPostData.ts
+++ b/app/lib/getDetailPostData.ts
@@ -2,7 +2,7 @@ import { API_PATH } from '../constants/path';
 import { JOB_DETAIL_DTO } from '../types';
 
 export const getDetailPostData = async (jobId: string): Promise<JOB_DETAIL_DTO> => {
-  const url = `${process.env.NEXT_PUBLIC_URL}${API_PATH.JOBS}/${jobId}`;
+  const url = `${process.env.NEXT_PUBLIC_URL}${API_PATH.POSTS}/${jobId}`;
   const res = await fetch(url);
   if (!res.ok) {
     throw new Error('Failed to fetch data');

--- a/app/lib/post/likeReplyComment.ts
+++ b/app/lib/post/likeReplyComment.ts
@@ -1,0 +1,25 @@
+import { API_PATH } from '@/app/constants/path';
+
+const likeReplyComment = async (
+  postId: number,
+  commentId: number //대댓글 id
+) => {
+  const url = `${process.env.NEXT_PUBLIC_URL}${API_PATH.POSTS}/comments/comments/${commentId}/likes?postId=${postId}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+  if (!res.ok) {
+    throw new Error('Faild to fetch data');
+  }
+
+  if (res) {
+    return res.json();
+  } else {
+    return null;
+  }
+};
+
+export default likeReplyComment;

--- a/app/lib/post/postReplyComment.ts
+++ b/app/lib/post/postReplyComment.ts
@@ -1,0 +1,25 @@
+const postReplyComment = async (
+  userId: number,
+  reComments: string,
+  postId: number,
+  commentId: number
+) => {
+  const url = `${process.env.NEXT_PUBLIC_URL}/comments/${reComments}/comments?userId=${userId}&postId=${postId}&commentId=${commentId}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+  if (!res.ok) {
+    throw new Error('Faild to fetch data');
+  }
+
+  if (res) {
+    return res.json();
+  } else {
+    return null;
+  }
+};
+
+export default postReplyComment;

--- a/app/lib/post/reportReplyComment.ts
+++ b/app/lib/post/reportReplyComment.ts
@@ -1,0 +1,25 @@
+import { API_PATH } from '@/app/constants/path';
+
+const reportReplyComment = async (
+  postId: number,
+  commentId: number //대댓글 id
+) => {
+  const url = `${process.env.NEXT_PUBLIC_URL}${API_PATH.POSTS}/comments/comments/${commentId}/reports?postId=${postId}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    }
+  });
+  if (!res.ok) {
+    throw new Error('Faild to fetch data');
+  }
+
+  if (res) {
+    return res.json();
+  } else {
+    return null;
+  }
+};
+
+export default reportReplyComment;

--- a/mocks/handler/postHandler.ts
+++ b/mocks/handler/postHandler.ts
@@ -1059,55 +1059,57 @@ export const PostHandlers = [
     }
   }),
   // 게시글 전체조회
-  http.post(`${API_PATH.JOBS}`, () => {
+  http.post(`${API_PATH.POSTS}`, () => {
     return HttpResponse.json(JOB_POSTS);
   }),
   // 게시글 상세조회
-  http.get(`${API_PATH.JOBS}/:jobId`, () => {
+  http.get(`${API_PATH.POSTS}/:jobId`, () => {
     return HttpResponse.json(JOB_POST_DETAIL);
   }),
   // 게시글 작성
-  http.post(`${API_PATH.JOBS}`, () => {
+  http.post(`${API_PATH.POSTS}`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 게시글 삭제
-  http.delete(`${API_PATH.JOBS}/:jobId`, () => {
+  http.delete(`${API_PATH.POSTS}/:jobId`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 게시글 수정
-  http.patch(`${API_PATH.JOBS}/:jobId`, () => {
+  http.patch(`${API_PATH.POSTS}/:jobId`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 게시글 댓글 작성
-  http.post(`${API_PATH.JOBS}/:postId/comments`, () => {
+  http.post(`${API_PATH.POSTS}/:postId/comments`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 댓글 신고
-  http.post(`${API_PATH.JOBS}/comments/:commentId/reports`, () => {
+  http.post(`${API_PATH.POSTS}/comments/:commentId/reports`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 댓글 좋아요
-  http.post(`${API_PATH.JOBS}/comments/:commentId/likes`, () => {
+  http.post(`${API_PATH.POSTS}/comments/:commentId/likes`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 댓글 삭제
-  http.delete(`${API_PATH.JOBS}/comments/:commentId`, () => {
+  http.delete(`${API_PATH.POSTS}/comments/:commentId`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 게시글 대댓글 작성
-  http.post(`${API_PATH.JOBS}/comments/:reComments/comments`, () => {
-    return HttpResponse.json(SuccessData);
+  http.post(`${API_PATH.POSTS}/comments/:reComments/comments`, ({ request }) => {
+    const url = new URL(request.url);
+    const postId = url.searchParams.get('postId');
+    return postId && HttpResponse.json(SuccessData);
   }),
   // 게시글 대댓글 좋아요
-  http.post(`${API_PATH.JOBS}/comments/comments/:commentId/likes`, () => {
+  http.post(`${API_PATH.POSTS}/comments/comments/:commentId/likes`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 게시글 대댓글 신고
-  http.post(`${API_PATH.JOBS}/comments/comments/:commentId/reports`, () => {
+  http.post(`${API_PATH.POSTS}/comments/comments/:commentId/reports`, () => {
     return HttpResponse.json(SuccessData);
   }),
   // 게시글 대댓글 삭제
-  http.delete(`${API_PATH.JOBS}/comments/comments/:commentId`, () => {
+  http.delete(`${API_PATH.POSTS}/comments/comments/:commentId`, () => {
     return HttpResponse.json(SuccessData);
   })
 ];


### PR DESCRIPTION
## 작업 사항

1. 댓글 api 연결 (삭제, 좋아요, 신고)
2. 대댓글 api 연결 (삭제, 좋아요, 신고)
3. post data 받아오는 handler 수정
4. post page 불러오는 url 수정


## 스크린샷/GIF
![image](https://github.com/SMUING-D/FE-Next/assets/104924817/f87e87f5-1a80-467d-8cd4-f5bf010d77be)



## 작업 사항
- [ ] 댓글 api 연결 (삭제, 좋아요, 신고)
- [x] 대댓글 api 연결 (삭제, 좋아요, 신고)
- [ ] post data 받아오는 handler 수정
- [ ] post page 불러오는 url 수정


## 이슈/건의/전달 사항
- [ ] 아직 머지 아닙니다
- [ ] 지금 post data 이상하게 불러와서 데이터 불러오는 handler부분 수정이 필요합니다.
- [ ] 근데 이거 계속 하려면 post page 불러오는 url 다시 설정해야하지 않을까요? /post/coe/job/1 이런식으로.. 아님 말구요..
- [ ]  그래서 실제로 api 연결해보기에도 애매해서 query 부분 머지되면 다시 이어서 해야 할 것 같습니다..
